### PR TITLE
Fix Null Crash

### DIFF
--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -134,7 +134,7 @@ static dispatch_group_t http_request_operation_completion_group() {
                 } else {
                     if (success) {
                         dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
-                            success(self, responseObject);
+                          success(self, responseObject ?: @"");
                         });
                     }
                 }

--- a/AFNetworking/AFHTTPRequestOperation.m
+++ b/AFNetworking/AFHTTPRequestOperation.m
@@ -134,7 +134,7 @@ static dispatch_group_t http_request_operation_completion_group() {
                 } else {
                     if (success) {
                         dispatch_group_async(self.completionGroup ?: http_request_operation_completion_group(), self.completionQueue ?: dispatch_get_main_queue(), ^{
-                          success(self, responseObject ?: @"");
+                          success(self, responseObject != nil ? responseObject : @"");
                         });
                     }
                 }


### PR DESCRIPTION
Since upgrading to Xcode 9.3, we've been getting a crash in the AFNetworking library if the server returns a null response. This simply returns an empty string if the `responseObject` is `nil`